### PR TITLE
Allow agent to call endpoint on boot

### DIFF
--- a/jenkins-agent/Dockerfile
+++ b/jenkins-agent/Dockerfile
@@ -61,3 +61,8 @@ RUN su jenkins -c 'bash /tool/google-cloud-sdk/install.sh --quiet'
 ENV JAVA8_HOME=/tool/jdk8/jdk8u242-b08
 ENV NODE_HOME=/tool/node-lts
 ENV PATH=${PATH}:${NODE_HOME}/bin:/tool
+
+COPY boot-sequence.sh /boot-sequence.sh
+RUN chmod 0755 /boot-sequence.sh
+
+ENTRYPOINT [ "tiny", "--", "/boot-sequence.sh" ]

--- a/jenkins-agent/boot-sequence.sh
+++ b/jenkins-agent/boot-sequence.sh
@@ -1,30 +1,56 @@
 #!/bin/bash
 set -e -o pipefail
 
+if [ -z "${CALL_HOME}" -a ! -z "${JENKINS_URL}" ]; then
+    CALL_HOME="${JENKINS_URL}/tcpSlaveAgentListener/"
+fi
+
+# Check if we can get a valid response from our home.
+#
+# A valid response is anything that returns 2xx status
+#
+# Globals:
+#   None
+# Arguments:
+#   homeUrl: contains the url used to execute a http get request
+# Returns:
+#   1 if an error happened / 0 if everything is OK.
 function call-home {
-    curl -q -fsSLk "${CALL_HOME}" || { echo "Unable to call home ${CALL_HOME}" >&2; return 1; }
+    declare -r homeUrl="${1}"
+    curl -q -fsSLk "${homeUrl}" || { echo "Unable to call home ${homeUrl}" >&2; return 1; }
     return 0
 }
 
+# Try to _call-home_ up to N times with a fixed delay between calls
+#
+# Globals:
+#   None
+# Arguments:
+#   homeUrl: contains the url used to execute a http get request
+#   loopCount: how many attempts before indicating a failure
+#   delay: how many seconds to sleep between each attempt
+# Returns:
+#   1 if an error happened / 0 if everything is OK.
 function try-call-home {
+    declare -r homeUrl="${1}"
+    declare -r loopCount="${2:-6}"
+    declare -r delay="${3:-10}"
     declare count=0
-    while ! call-home; do
+    while ! call-home "${homeUrl}"; do
         count=$(($count+1))
         case "${count}" in
-            6)
+            "${loopCount}")
                 return 1
                 ;;
             *)
-                sleep 10
+                sleep "${delay}"
                 ;;
         esac
     done
 }
 
-if [ ! -z "${CALL_HOME}" ]; then
-    if ! try-call-home; then
-        echo "Unable to call home after many attempts. Do we have connection to external resources" >&2
-    fi
+if ! try-call-home "${CALL_HOME}" "${CALL_HOME_ATTEMPTS}" "${CALL_HOME_DELAY}"; then
+    echo "Unable to call home after many attempts. Do we have connection to external resources" >&2
 fi
 
 source "/entrypoint.sh"

--- a/jenkins-agent/boot-sequence.sh
+++ b/jenkins-agent/boot-sequence.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e -o pipefail
+
+function call-home {
+    curl -q -fsSLk "${CALL_HOME}" || { echo "Unable to call home ${CALL_HOME}" >&2; return 1; }
+    return 0
+}
+
+function try-call-home {
+    declare count=0
+    while ! call-home; do
+        count=$(($count+1))
+        case "${count}" in
+            6)
+                return 1
+                ;;
+            *)
+                sleep 10
+                ;;
+        esac
+    done
+}
+
+if [ ! -z "${CALL_HOME}" ]; then
+    if ! try-call-home; then
+        echo "Unable to call home after many attempts. Do we have connection to external resources" >&2
+    fi
+fi
+
+source "/entrypoint.sh"


### PR DESCRIPTION
When running in k8s, connection resets might happen and *jnlp* agent doesn't like it.

Adding a boot-sequence.sh script to defer agent execution until a valid TCP connection can be established with Jenkins.

TODO: add a toggle to disable this feature as it is not a strict requirement for *all* types of agents.